### PR TITLE
Validate keys during initialization

### DIFF
--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -76,9 +76,9 @@ module JSONAPI
     private
 
     def validate(key)
-      unless valid?(key)
-        raise InvalidKey.new(key)
-      end
+      return if valid?(key)
+
+      raise InvalidKey, key
     end
 
     def valid?(key)

--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -14,15 +14,13 @@ module JSONAPI
   class IncludeDirective
     # @param include_args (see Parser.parse_include_args)
     def initialize(include_args, options = {})
-      @include_hash = Parser.parse_include_args(include_args)
+      include_hash = Parser.parse_include_args(include_args)
 
-      outer = options[:outer].nil? ? true : outer
-      @hash = @include_hash.each_with_object({}) do |(key, value), hash|
+      @hash = include_hash.each_with_object({}) do |(key, value), hash|
+        validate(key)
         hash[key] = self.class.new(value, outer: false, **options)
       end
       @options = options
-
-      validate if outer
     end
 
     # @param key [Symbol, String]
@@ -73,50 +71,18 @@ module JSONAPI
       string_array.join(',')
     end
 
-    class InvalidKey < StandardError
-      def initialize(keys)
-        @keys = keys
-      end
-
-      def message
-        @keys.join(',')
-      end
-    end
+    class InvalidKey < StandardError; end
 
     private
 
-    def validate
-      validation_result = deep_validate(to_hash)
-      invalid_keys = extract_invalid_keys(validation_result)
-
-      if invalid_keys.any?
-        raise InvalidKey.new(invalid_keys)
+    def validate(key)
+      unless valid?(key)
+        raise InvalidKey.new(key)
       end
-    end
-
-    def deep_validate(hash, parent_key = nil, parent_result = true)
-      hash.flat_map do |key, value|
-        current_key = [parent_key, key.to_s].compact.join(".")
-        current_result = valid?(key)
-
-        if value.any?
-          deep_validate(value, current_key, current_result)
-        else
-          { current_key => current_result && parent_result }
-        end
-      end
-    end
-
-    def extract_invalid_keys(validation_result)
-      validation_result.map do |result|
-        result.map do |key, is_valid|
-          key unless is_valid
-        end
-      end.flatten.compact
     end
 
     def valid?(key)
-      !!key.match(valid_json_key_name_regex)
+      key.match(valid_json_key_name_regex)
     end
 
     def valid_json_key_name_regex

--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -17,7 +17,8 @@ module JSONAPI
       include_hash = Parser.parse_include_args(include_args)
 
       @hash = include_hash.each_with_object({}) do |(key, value), hash|
-        validate(key)
+        raise InvalidKey, key unless valid?(key)
+
         hash[key] = self.class.new(value, outer: false, **options)
       end
       @options = options
@@ -74,12 +75,6 @@ module JSONAPI
     class InvalidKey < StandardError; end
 
     private
-
-    def validate(key)
-      return if valid?(key)
-
-      raise InvalidKey, key
-    end
 
     def valid?(key)
       key.match(valid_json_key_name_regex)

--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -14,11 +14,15 @@ module JSONAPI
   class IncludeDirective
     # @param include_args (see Parser.parse_include_args)
     def initialize(include_args, options = {})
-      include_hash = Parser.parse_include_args(include_args)
-      @hash = include_hash.each_with_object({}) do |(key, value), hash|
-        hash[key] = self.class.new(value, options)
+      @include_hash = Parser.parse_include_args(include_args)
+
+      outer = options[:outer].nil? ? true : outer
+      @hash = @include_hash.each_with_object({}) do |(key, value), hash|
+        hash[key] = self.class.new(value, outer: false, **options)
       end
       @options = options
+
+      validate if outer
     end
 
     # @param key [Symbol, String]
@@ -67,6 +71,59 @@ module JSONAPI
       end
 
       string_array.join(',')
+    end
+
+    class InvalidKey < StandardError
+      def initialize(keys)
+        @keys = keys
+      end
+
+      def message
+        @keys.join(',')
+      end
+    end
+
+    private
+
+    def validate
+      validation_result = deep_validate(to_hash)
+      invalid_keys = extract_invalid_keys(validation_result)
+
+      if invalid_keys.any?
+        raise InvalidKey.new(invalid_keys)
+      end
+    end
+
+    def deep_validate(hash, parent_key = nil, parent_result = true)
+      hash.flat_map do |key, value|
+        current_key = [parent_key, key.to_s].compact.join(".")
+        current_result = valid?(key)
+
+        if value.any?
+          deep_validate(value, current_key, current_result)
+        else
+          { current_key => current_result && parent_result }
+        end
+      end
+    end
+
+    def extract_invalid_keys(validation_result)
+      validation_result.map do |result|
+        result.map do |key, is_valid|
+          key unless is_valid
+        end
+      end.flatten.compact
+    end
+
+    def valid?(key)
+      !!key.match(valid_json_key_name_regex)
+    end
+
+    def valid_json_key_name_regex
+      # not start with hyphen/underscore/space
+      # not end with hyphen/underscore/space
+      # contains a-zA-Z, *  and hyphen/underscore/space in member names
+      /^(?![\s\-_])[\w\s\-\*]+(?<![\s\-_])$/
     end
   end
 end

--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -88,7 +88,7 @@ module JSONAPI
     def valid_json_key_name_regex
       # not start with hyphen/underscore/space
       # not end with hyphen/underscore/space
-      # contains a-zA-Z, *  and hyphen/underscore/space in member names
+      # contains a-zA-Z, 0-9, and hyphen/underscore/space in member names
       /^(?![\s\-_])[\w\s\-\*]+(?<![\s\-_])$/
     end
   end

--- a/spec/include_directive_spec.rb
+++ b/spec/include_directive_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 require 'jsonapi/include_directive'
 
 describe JSONAPI::IncludeDirective, '.initialize' do
-  it 'raises InvalidKey exception when keys are invalid in a fail-fast fashion' do
+  it 'raises InvalidKey when encounters invalid one' do
     valid_keys   = 'friends,post.comments'
     invalid_keys = ' leading.space,trailing.space '
 
     expect { JSONAPI::IncludeDirective.new("#{valid_keys},#{invalid_keys}") }
-      .to raise_error(JSONAPI::IncludeDirective::InvalidKey, " leading")
+      .to raise_error(JSONAPI::IncludeDirective::InvalidKey, ' leading')
   end
 end
 

--- a/spec/include_directive_spec.rb
+++ b/spec/include_directive_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 require 'jsonapi/include_directive'
 
+describe JSONAPI::IncludeDirective, '.initialize' do
+  it 'raises InvalidKey exception when keys are invalid' do
+    valid_keys   = 'friends,post.comments'
+    invalid_keys = ' leading.space,trailing.space ,middle. space'
+
+    expect { JSONAPI::IncludeDirective.new("#{valid_keys},#{invalid_keys}") }.
+      to raise_error(JSONAPI::IncludeDirective::InvalidKey, invalid_keys)
+  end
+end
+
 describe JSONAPI::IncludeDirective, '.key?' do
   it 'handles existing keys' do
     str = 'posts.comments'

--- a/spec/include_directive_spec.rb
+++ b/spec/include_directive_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 require 'jsonapi/include_directive'
 
 describe JSONAPI::IncludeDirective, '.initialize' do
-  it 'raises InvalidKey exception when keys are invalid' do
+  it 'raises InvalidKey exception when keys are invalid in a fail-fast fashion' do
     valid_keys   = 'friends,post.comments'
-    invalid_keys = ' leading.space,trailing.space ,middle. space'
+    invalid_keys = ' leading.space,trailing.space '
 
-    expect { JSONAPI::IncludeDirective.new("#{valid_keys},#{invalid_keys}") }.
-      to raise_error(JSONAPI::IncludeDirective::InvalidKey, invalid_keys)
+    expect { JSONAPI::IncludeDirective.new("#{valid_keys},#{invalid_keys}") }
+      .to raise_error(JSONAPI::IncludeDirective::InvalidKey, " leading")
   end
 end
 


### PR DESCRIPTION
(Follow up https://github.com/jsonapi-rb/jsonapi-renderer/issues/16)

Raises `InvalidKey` exception when initialization:

```ruby
JSONAPI::IncludeDirective.new("friends, comments, posts, author.posts")
# JSONAPI::IncludeDirective::InvalidKey:  comments
```

(@beauby Still quite a rough implementation, just to see if this is something we want. If so I'll continue do some refactoring, handling hounds and probably extracting the validation part to its own class 🙂)