### PR TITLE
Let cache handle marshalling of results.

### DIFF
--- a/lib/jsonapi/renderer/cached_resources_processor.rb
+++ b/lib/jsonapi/renderer/cached_resources_processor.rb
@@ -13,7 +13,7 @@ module JSONAPI
           cache_hash = cache_key_map(resources)
           processed_resources = @cache.fetch_multi(*cache_hash.keys) do |key|
             res, include, fields = cache_hash[key]
-            json = res.as_jsonapi(include: include, fields: fields)
+            res.as_jsonapi(include: include, fields: fields)
           end
 
           resources.replace(processed_resources.values)

--- a/lib/jsonapi/renderer/cached_resources_processor.rb
+++ b/lib/jsonapi/renderer/cached_resources_processor.rb
@@ -4,12 +4,6 @@ module JSONAPI
   class Renderer
     # @private
     class CachedResourcesProcessor < ResourcesProcessor
-      class JSONString < String
-        def to_json(*)
-          self
-        end
-      end
-
       def initialize(cache)
         @cache = cache
       end
@@ -17,11 +11,9 @@ module JSONAPI
       def process_resources
         [@primary, @included].each do |resources|
           cache_hash = cache_key_map(resources)
-          processed_resources = @cache.fetch_multi(cache_hash.keys) do |key|
+          processed_resources = @cache.fetch_multi(*cache_hash.keys) do |key|
             res, include, fields = cache_hash[key]
-            json = res.as_jsonapi(include: include, fields: fields).to_json
-
-            JSONString.new(json)
+            json = res.as_jsonapi(include: include, fields: fields)
           end
 
           resources.replace(processed_resources.values)

--- a/spec/caching_spec.rb
+++ b/spec/caching_spec.rb
@@ -5,7 +5,7 @@ class Cache
     @cache = {}
   end
 
-  def fetch_multi(keys)
+  def fetch_multi(*keys)
     keys.each_with_object({}) do |k, h|
       @cache[k] = yield(k) unless @cache.key?(k)
       h[k] = @cache[k]
@@ -96,6 +96,6 @@ describe JSONAPI::Renderer, '#render' do
     }
 
     expect(JSON.parse(actual.to_json)).to eq(JSON.parse(expected.to_json))
-    expect(actual[:data]).to be_a(JSONAPI::Renderer::CachedResourcesProcessor::JSONString)
+    expect(actual[:data]).to be_a(Hash)
   end
 end


### PR DESCRIPTION
Also multi_fetch should use the splat operator.
http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch_multi