### PR TITLE
Unify Simple and Cached resource output – both returns array of hash objects

### DIFF
--- a/lib/jsonapi/renderer/cached_resources_processor.rb
+++ b/lib/jsonapi/renderer/cached_resources_processor.rb
@@ -4,12 +4,6 @@ module JSONAPI
   class Renderer
     # @private
     class CachedResourcesProcessor < ResourcesProcessor
-      class JSONString < String
-        def to_json(*)
-          self
-        end
-      end
-
       def initialize(cache)
         @cache = cache
       end
@@ -19,9 +13,7 @@ module JSONAPI
           cache_hash = cache_key_map(resources)
           processed_resources = @cache.fetch_multi(*cache_hash.keys) do |key|
             res, include, fields = cache_hash[key]
-            json = res.as_jsonapi(include: include, fields: fields).to_json
-
-            JSONString.new(json)
+            res.as_jsonapi(include: include, fields: fields)
           end
 
           resources.replace(processed_resources.values)

--- a/spec/caching_spec.rb
+++ b/spec/caching_spec.rb
@@ -96,6 +96,6 @@ describe JSONAPI::Renderer, '#render' do
     }
 
     expect(JSON.parse(actual.to_json)).to eq(JSON.parse(expected.to_json))
-    expect(actual[:data]).to be_a(JSONAPI::Renderer::CachedResourcesProcessor::JSONString)
+    expect(actual[:data]).to be_a(Hash)
   end
 end


### PR DESCRIPTION
This change unifies the output type of `SimpleResourcesProcessor` and `CachedResourcesProcessor`. 

Before:
```Ruby
# No caching
result = JSONAPI::Serializable::Renderer.new(cache: false).render(collection)
result[:data].first.class # => Hash

# With caching
result = JSONAPI::Serializable::Renderer.new(cache: Rails.cache).render(collection)
result[:data].first.class # => String

# Parsing needed if you want to personalize result
result[:data] = json[:data].map { |json_string| JSON.parse(json_string) }
```

After:
```Ruby
# No caching
result = JSONAPI::Serializable::Renderer.new(cache: false).render(collection)
result[:data].first.class # => Hash

# With caching
result = JSONAPI::Serializable::Renderer.new(cache: Rails.cache).render(collection)
result[:data].first.class # => Hash
```




That's very important if you need to amend/personalize output of the `JSONAPI::Serializable::Renderer`.