### PR TITLE
Ensure dashes and underscores are permitted in key names

### DIFF
--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -81,7 +81,7 @@ module JSONAPI
 
     def valid_json_key_name_regex
       # https://jsonapi.org/format/#document-member-names
-      /^(?![\s\-_])[\u0080-\u10FFFFA-Za-z0-9*]+(?<![\s\-_])$/
+      /^(?![\s\-_])[\u0080-\u10FFA-Za-z0-9* _-]+(?<![\s\-_])$/
     end
   end
 end

--- a/spec/include_directive_spec.rb
+++ b/spec/include_directive_spec.rb
@@ -31,10 +31,17 @@ describe JSONAPI::IncludeDirective, '.initialize' do
     end
   end
 
-  context 'not raises InvalidKey' do
+  context 'does not raise InvalidKey' do
     ["\u0080", "B", "t", "5", "\u0100", "\u10FFFAA"].each do |char|
-      it "when provided characher '#{char}'" do
+      it "when provided character '#{char}'" do
         expect(JSONAPI::IncludeDirective.new(char).key?(char)).to be true
+      end
+    end
+
+    [' ', '_', '-'].each do |char|
+      it "when '#{char}' is not at beginning or end" do
+        key = "valid#{char}valid"
+        expect(JSONAPI::IncludeDirective.new(key).key?(key)).to be true
       end
     end
   end


### PR DESCRIPTION
The validation added #36 is too strict, it doesn't allow underscores, hyphens, and spaces. These are supposed to be permissible as long as they don't come at the beginning or end.

This makes the following changes to the ReGex:
- Add " ", "_", and "-" to the allowed middle of word characters
- Change "\u10FFFFA" to "\u10FF". This caused a warning from Ruby  because it doesn't understand utf16 codes and the extra F and A  characters were interpreted as literals.

Fixes #37