### PR TITLE
resources_processor: speed up rendering by using Hash instead of Set

### DIFF
--- a/lib/jsonapi/renderer/cached_resources_processor.rb
+++ b/lib/jsonapi/renderer/cached_resources_processor.rb
@@ -15,11 +15,6 @@ module JSONAPI
       end
 
       def process_resources
-        # NOTE(beauby): This is necessary for cache keys consistency.
-        @include_rels = @include_rels.each_with_object({}) do |(k, v), h|
-          h[k] = v.to_a.sort!
-        end
-
         [@primary, @included].each do |resources|
           cache_hash = cache_key_map(resources)
           processed_resources = @cache.fetch_multi(*cache_hash.keys) do |key|
@@ -36,7 +31,9 @@ module JSONAPI
       def cache_key_map(resources)
         resources.each_with_object({}) do |res, h|
           ri = [res.jsonapi_type, res.jsonapi_id]
-          include_dir = @include_rels[ri]
+          include_rels = @include_rels[ri]
+          # Sort for cache key consistency
+          include_dir = include_rels.keys.sort unless include_rels.nil?
           fields = @fields[ri.first.to_sym]
           h[res.jsonapi_cache_key(include: include_dir, fields: fields)] =
             [res, include_dir, fields]

--- a/lib/jsonapi/renderer/simple_resources_processor.rb
+++ b/lib/jsonapi/renderer/simple_resources_processor.rb
@@ -8,7 +8,7 @@ module JSONAPI
         [@primary, @included].each do |resources|
           resources.map! do |res|
             ri = [res.jsonapi_type, res.jsonapi_id]
-            include_dir = @include_rels[ri]
+            include_dir = @include_rels[ri].keys
             fields = @fields[res.jsonapi_type.to_sym]
             res.as_jsonapi(include: include_dir, fields: fields)
           end


### PR DESCRIPTION
According to [a conference I just watched](https://www.youtube.com/watch?v=xii1oyad_kc&feature=youtu.be&t=638) the `Set` class is very slow compared to simple Hash because of optimizations in the MRI for Hash accesses.

So here is a PR that replaces Set with Hash. It results with a speed increase (can be up to 30%)

Here is the code of the benchmark and it's results before/after the patch: https://gist.github.com/alchimere/323a4803981e48fed2ce86ac5027693a