### PR TITLE
Handle duplicate includes

### DIFF
--- a/lib/jsonapi/renderer/resources_processor.rb
+++ b/lib/jsonapi/renderer/resources_processor.rb
@@ -59,7 +59,23 @@ module JSONAPI
       end
 
       def include_duplicate_resource(res)
-        duplicate_index = @included.find_index do |included|
+        duplicate_index = find_included_duplicate_resource(res)
+
+        return unless duplicate_index
+
+        duplicate = @included.delete_at(duplicate_index)
+
+        if duplicate.is_a?(Array)
+          duplicate << res
+        else
+          duplicate = [duplicate, res]
+        end
+
+        @included << duplicate
+      end
+
+      def find_included_duplicate_resource(res)
+        @included.find_index do |included|
           if included.is_a?(Array)
             unless included.empty?
               included.first.jsonapi_type == res.jsonapi_type && included.first.jsonapi_id == res.jsonapi_id
@@ -67,18 +83,6 @@ module JSONAPI
           else
             included.jsonapi_type == res.jsonapi_type && included.jsonapi_id == res.jsonapi_id
           end
-        end
-
-        if duplicate_index
-          duplicate = @included.delete_at(duplicate_index)
-
-          if duplicate.is_a?(Array)
-            duplicate << res
-          else
-            duplicate = [duplicate, res]
-          end
-
-          @included << duplicate
         end
       end
 

--- a/lib/jsonapi/renderer/resources_processor.rb
+++ b/lib/jsonapi/renderer/resources_processor.rb
@@ -50,9 +50,35 @@ module JSONAPI
 
         if @include_rels.include?(ri)
           @include_rels[ri].merge!(keys_hash)
+
+          include_duplicate_resource(res) unless primary
         else
           @include_rels[ri] = keys_hash
           (primary ? @primary : @included) << res
+        end
+      end
+
+      def include_duplicate_resource(res)
+        duplicate_index = @included.find_index do |included|
+          if included.is_a?(Array)
+            unless included.empty?
+              included.first.jsonapi_type == res.jsonapi_type && included.first.jsonapi_id == res.jsonapi_id
+            end
+          else
+            included.jsonapi_type == res.jsonapi_type && included.jsonapi_id == res.jsonapi_id
+          end
+        end
+
+        if duplicate_index
+          duplicate = @included.delete_at(duplicate_index)
+
+          if duplicate.is_a?(Array)
+            duplicate << res
+          else
+            duplicate = [duplicate, res]
+          end
+
+          @included << duplicate
         end
       end
 

--- a/lib/jsonapi/renderer/simple_resources_processor.rb
+++ b/lib/jsonapi/renderer/simple_resources_processor.rb
@@ -7,12 +7,51 @@ module JSONAPI
       def process_resources
         [@primary, @included].each do |resources|
           resources.map! do |res|
-            ri = [res.jsonapi_type, res.jsonapi_id]
-            include_dir = @include_rels[ri].keys
-            fields = @fields[res.jsonapi_type.to_sym]
-            res.as_jsonapi(include: include_dir, fields: fields)
+            # Duplicates array
+            if res.is_a?(Array)
+              process_duplicates(res)
+            # Regular resource case
+            else
+              process_resource(res)
+            end
           end
         end
+      end
+
+      def process_resource(resource)
+        ri = [resource.jsonapi_type, resource.jsonapi_id]
+        include_dir = @include_rels[ri].keys
+        fields = @fields[resource.jsonapi_type.to_sym]
+        resource.as_jsonapi(include: include_dir, fields: fields)
+      end
+
+      def process_duplicates(duplicates)
+        return unless duplicates.is_a?(Array) && duplicates.any?
+
+        duplicates.inject({}) do |result, duplicate|
+          if result.empty?
+            result = process_resource(duplicate) if result.empty?
+          else
+            duplicate_result = process_resource(duplicate)
+            result = deep_merge_duplicate_hashes(result, duplicate_result)
+          end
+        end
+      end
+
+      def deep_merge_duplicate_hashes(hash1, hash2)
+        merger = proc do |_, v1, v2|
+          if v1.is_a?(Hash) && v2.is_a?(Hash)
+            v1.merge(v2, &merger)
+          elsif v1.is_a?(Array) && v2.is_a?(Array)
+            v1 | v2
+          elsif [:undefined, nil, :nil].include?(v2)
+            v1
+          else
+            v2
+          end
+        end
+
+        hash1.merge(hash2, &merger)
       end
     end
   end


### PR DESCRIPTION
This PR enables rendering multiple included resources together by grouping them in arrays first (if their `jsonapi_type` and `jsonapi_id` are the same) and then rendering them one-by-one while merging the rendering results.

Rationale: we use Rails and [Graphiti](https://github.com/graphiti-api/graphiti) and encountered the following problem: we added a few relationships (e.g. `specific`) that are not represented in corresponding models to Graphiti `Resource`s (that are basically JSON:API wrappers). Then we have a child resource (that obviously goes into `@included` array) that contains these specific relationships and is referenced by two different paths from a parent resource (e.g. `path1` and `path2`). Then we have a complex request for the parent resource, including two references to the same child object with the first reference requesting the specific resource while the second reference is not (something like `include=path1.specific,path2`). When Graphiti is processing the request it enriches the first referenced object with these specific relationships while leaving the second object alone with no modifications. In this case we have two different objects with the same `jsonapi_type` and `jsonapi_id` but with slightly different behavior. Sadly when squashing the references tree into simple `@primary` and `@included` objects (in `traverse_resources`) we enrich all includes (by merging includes in the `@include_rels`) but we leave **only one resource** (which may miss these specific relationships). And so when trying to process includes from this resource we end up with a relationship with `data: nil` since this resource misses the `specific` relationship.

BTW it is interesting that somehow the rightmost reference in the `include` parameter is processed first, so the result is dependent on the order of includes. If we use `include=path2,path1.specific` we will have proper data in the response.

Edit: it is not the rightmost reference that matters but a combination of a field (relationship) definition inside the resource and the `include` reference (which field is used in the `include` section)